### PR TITLE
feat: Allow pass user agent to the webview

### DIFF
--- a/android/src/main/java/com/teamhive/capacitor/webviewoverlay/WebviewOverlayPlugin.java
+++ b/android/src/main/java/com/teamhive/capacitor/webviewoverlay/WebviewOverlayPlugin.java
@@ -101,6 +101,10 @@ public class WebviewOverlayPlugin extends Plugin {
                 settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
                 settings.setDomStorageEnabled(true);
                 settings.setSupportMultipleWindows(true);
+                String userAgent = call.getString("userAgent", "");
+                if (!userAgent.isEmpty()) {
+                    settings.setUserAgentString(String.format("%s %s", settings.getUserAgentString(), userAgent));
+                }
 
                 // Temp fix until this setting is on by default
                 bridge.getWebView().getSettings().setJavaScriptCanOpenWindowsAutomatically(true);
@@ -278,6 +282,8 @@ public class WebviewOverlayPlugin extends Plugin {
                 int count = rootGroup.getChildCount();
                 if (count > 1) {
                     rootGroup.removeView(webView);
+                    webView.destroyDrawingCache();
+                    webView.destroy()
                     webView = null;
                 }
                 hidden = false;

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -202,6 +202,10 @@ public class WebviewOverlayPlugin: CAPPlugin {
             webConfiguration.allowsInlineMediaPlayback = true
             webConfiguration.mediaTypesRequiringUserActionForPlayback = []
             webConfiguration.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
+            let userAgent = call.getString("userAgent");
+            if (userAgent) {
+                webConfiguration.applicationNameForUserAgent = "\(webConfiguration.applicationNameForUserAgent), \(userAgent)";
+            }
 
             // Content controller
             let javascript = call.getString("javascript") ?? ""

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -46,6 +46,7 @@ interface OpenOptions extends Dimensions {
 
     javascript?: string;
     injectionTime?: ScriptInjectionTime;
+    userAgent?: string;
 }
 
 interface Dimensions {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,6 +21,11 @@ export interface WebviewOverlayOpenOptions {
      * When toggled off, the element will have a background image with the webview snapshot.
      */
     element: HTMLElement;
+
+    /**
+     * Allow use append the string to the end of the user agent.
+     */
+    userAgent?: string;
 }
 
 class WebviewOverlayClass {
@@ -64,6 +69,7 @@ class WebviewOverlayClass {
         return WebviewOverlayPlugin.open({
             url: options.url,
             javascript: options.script ? options.script.javascript : '',
+            userAgent: options.userAgent ? options.userAgent : '',
             injectionTime: options.script ? (options.script.injectionTime || ScriptInjectionTime.atDocumentStart) : ScriptInjectionTime.atDocumentStart,
             width: Math.round(boundingBox.width),
             height: Math.round(boundingBox.height),


### PR DESCRIPTION
We (at @loveholidays) have the need of append a text to the user agent to the webview in order to differentiate and change the experience from the browser.

Also noticed that on android the webview was being kept live after destroying so I've fixed in this PR.

Let me know if there is more to add 👍🏻 